### PR TITLE
Update error-chain

### DIFF
--- a/lexer/Cargo.toml
+++ b/lexer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 publish = false
 
 [dependencies]
-error-chain = "0.11.0-rc.2"
+error-chain = "0.11.0"
 nafi-tokens = { path = "../tokens/" }
 nnom = { path = "../nnom/" }
 


### PR DESCRIPTION
0.11.0 is out, stop using the release candidate