### PR TITLE
Match default binding modes are stable, remove some `ref`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
   include:
   
   # Warnings/Docs
-  - rust: nightly-2018-03-28
+  - rust: nightly-2018-04-06
     env: RUSTFLAGS="-D warnings" CARGO_GHP_VERSION="0.3.2"
     install:
     - cargo install cargo-ghp-upload --verbose --version $CARGO_GHP_VERSION || true
@@ -37,12 +37,11 @@ matrix:
     - cargo ghp-upload -vvvr
   
   # Clippy/Format
-  - rust: nightly-2018-03-28
-  # # waiting on rust-lang-nursery/rust-clippy#2587 rust-lang-nursery/rust-clippy#2585
-    env: CLIPPY_VERSION="0.0.190"
+  - rust: nightly-2018-04-06
+    env: CLIPPY_VERSION="0.0.193"
     install:
     - rustup component add rustfmt-preview || true
     - cargo install clippy --verbose --version $CLIPPY_VERSION || true
     script:
-    - cargo clippy --all -- -D clippy
+    - cargo clippy --all-targets --tests -- -D clippy
     - cargo fmt -- --write-mode=diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
   include:
   
   # Warnings/Docs
-  - rust: nightly-2018-04-06
+  - rust: nightly-2018-04-07
     env: RUSTFLAGS="-D warnings" CARGO_GHP_VERSION="0.3.2"
     install:
     - cargo install cargo-ghp-upload --verbose --version $CARGO_GHP_VERSION || true
@@ -37,7 +37,7 @@ matrix:
     - cargo ghp-upload -vvvr
   
   # Clippy/Format
-  - rust: nightly-2018-04-06
+  - rust: nightly-2018-04-07
     env: CLIPPY_VERSION="0.0.193"
     install:
     - rustup component add rustfmt-preview || true

--- a/ast/src/declaration.rs
+++ b/ast/src/declaration.rs
@@ -10,8 +10,8 @@ pub enum Declaration<'a> {
 
 impl<'a> Declaration<'a> {
     pub fn span(&self) -> Span {
-        match *self {
-            Declaration::Binding(ref decl) => decl.span,
+        match self {
+            Declaration::Binding(decl) => decl.span,
         }
     }
 }

--- a/ast/src/expression.rs
+++ b/ast/src/expression.rs
@@ -15,12 +15,12 @@ pub enum Expression<'a> {
 
 impl<'a> Expression<'a> {
     pub fn span(&self) -> Span {
-        match *self {
-            Expression::Identifier(ref expr) => expr.span,
-            Expression::Parenthesized(ref expr) => expr.span,
-            Expression::BinaryOperator(ref expr) => expr.span,
-            Expression::IntegerLiteral(ref expr) => expr.span,
-            Expression::StringLiteral(ref expr) => expr.span,
+        match self {
+            Expression::Identifier(expr) => expr.span,
+            Expression::Parenthesized(expr) => expr.span,
+            Expression::BinaryOperator(expr) => expr.span,
+            Expression::IntegerLiteral(expr) => expr.span,
+            Expression::StringLiteral(expr) => expr.span,
         }
     }
 }

--- a/ast/src/statement.rs
+++ b/ast/src/statement.rs
@@ -12,10 +12,10 @@ pub enum Statement<'a> {
 
 impl<'a> Statement<'a> {
     pub fn span(&self) -> Span {
-        match *self {
-            Statement::Declaration(ref decl) => decl.span(),
-            Statement::Assignment(ref assign) => assign.span,
-            Statement::Expression(ref expr) => expr.span(),
+        match self {
+            Statement::Declaration(decl) => decl.span(),
+            Statement::Assignment(assign) => assign.span,
+            Statement::Expression(expr) => expr.span(),
         }
     }
 }

--- a/tokens/src/lib.rs
+++ b/tokens/src/lib.rs
@@ -132,13 +132,13 @@ impl<'a> From<&'a str> for StringFragment<'a> {
 impl<'a> StringFragment<'a> {
     fn dump<W: io::Write>(&self, depth: usize, w: &mut W) -> io::Result<()> {
         let indent = " ".repeat(depth);
-        match *self {
+        match self {
             StringFragment::Literal(s) => write!(w, "{}Literal({:?})", indent, s),
             StringFragment::Escaped(c) => write!(w, "{}Escaped({})", indent, c.escape_default()),
             StringFragment::InvalidEscape(pos, s) => {
                 write!(w, "{}InvalidEscape({:?})@{}", indent, s, pos)
             },
-            StringFragment::Interpolated(ref tokens) => {
+            StringFragment::Interpolated(tokens) => {
                 write!(w, "{}Interpolation", indent)?;
                 for token in tokens {
                     writeln!(w)?;


### PR DESCRIPTION
bors: r+