### PR TITLE
Fix tarpaulin coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,11 @@ matrix:
         apt:
           packages:
             - libssl-dev
-            - pkg-config
-            - cmake
-            - zlib1g-dev
       install:
         - cargo install cargo-update || true
         - cargo install-update -i cargo-tarpaulin cargo-update
       script:
-        - cargo +nightly tarpaulin --verbose --out Xml
+        - cargo +nightly tarpaulin --out Xml
         - bash <(curl -s https://codecov.io/bash)
 
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
-    - rust: nightly
-    - install:
-      - cargo install cargo-tarpaulin
+    - name: coverage
 
   include:
     - name: tests
@@ -43,7 +41,7 @@ matrix:
         - cargo fmt -- --check
 
     - name: coverage
-      rust: nightly
+      rust: nightly-2018-10-13
       sudo: required
       env:
         - RUSTFLAGS="--cfg procmacro2_semver_exempt"
@@ -55,7 +53,7 @@ matrix:
         - cargo install cargo-update || true
         - cargo install-update -i cargo-tarpaulin cargo-update
       script:
-        - cargo +nightly tarpaulin --out Xml
+        - cargo tarpaulin --out Xml
         - bash <(curl -s https://codecov.io/bash)
 
     - stage: deploy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [workspace]
 
 members = [

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "nafi-parser"
 version = "0.0.0"

--- a/parser/repl/Cargo.toml
+++ b/parser/repl/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "nafi-parser-repl"
 version = "0.0.0"

--- a/wasm-api/Cargo.toml
+++ b/wasm-api/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition"]
+
 [package]
 name = "nafi-wasm-api"
 version = "0.0.0"


### PR DESCRIPTION
This is a test PR to see how it goes on CI.

The suspected issue is that the version of cargo tarpaulin is using isn't up-to-beta-date, so edition needs to be opt-in. If this causes build issues in the `clippy -D warnings` build, I'll just let coverage sit broken until editions are fully stable. (I actually don't even have any tests yet, so....)

https://github.com/xd009642/tarpaulin/issues/157

I would install from the develop branch but [`cargo install --git` uses master](https://github.com/rust-lang/cargo/issues/3517) and I don't think there's a way to change it.

If coverage passes, I'll play around with which manifests need the flag at least.